### PR TITLE
Updated smsModule to use a config file

### DIFF
--- a/modules/smsModule.py
+++ b/modules/smsModule.py
@@ -6,75 +6,63 @@ from email.MIMEBase import MIMEBase
 from email.MIMEText import MIMEText
 
 
+CONST_CONTACT = 2
+CONST_MESSAGE = 3
 
 
-def sendMail(to, text):
-	fromAddr = "phyll1s.rafibot@gmail.com"
-	password = "qwerty4u"
+def getContactList():
+	configFile = open('smsConfig','r')
+	contactList = configFile.readlines()
+	contactList = [x.replace('\n', '') for x in contactList]
+
+	return contactList
+
+def getContacts(contactList):
+	contacts = ''
+	for index, item in enumerate(contactList):
+		if index%2 == 0 and index>=2:
+			contacts += "| " + contactList[index]
+	return contacts[1:]
+	
+
+def sendMail(contactList, to, text):
+	fromAddr = contactList[0]
+	password = contactList[1]
+
+	toAddr = contactList[contactList.index(to) + 1]	
 
 	mailServer = smtplib.SMTP('smtp.gmail.com:587')
 	mailServer.ehlo()
 	mailServer.starttls()
 	mailServer.ehlo()
 	mailServer.login(fromAddr,password)
-	mailServer.sendmail(fromAddr,to,text)
+	mailServer.sendmail(fromAddr,toAddr,text)
 	mailServer.close()
 
-
-def getQuery(message):
-	expression = re.compile('(text|txt)( madsen| phyll1s| luke| stilts| jimmy| jimjim| mov1s| popa)? (.*)', re.IGNORECASE)
-	match = expression.match(message)
-	if match:
-		return match.group(3) 
-	else:
-		return None
 	
-def getContact(message):
-	expression = re.compile('(text|txt)( madsen| phyll1s| luke| stilts| jimmy| jimjim| mov1s| popa)? (.*)', re.IGNORECASE)
+def getQuery(contactList, message, messagePart):
+	stringMatch = "(text|txt)(" + getContacts(contactList) + ")? (.*)"
+	expression = re.compile(stringMatch, re.IGNORECASE)
 	match = expression.match(message)
 	if match:
-		return match.group(2) 
+		return match.group(messagePart).strip()
 	else:
 		return None
 	
 
 def main(irc):
-  	message = irc.lastMessage()
-	
+ 	message = irc.lastMessage()
+	contactList = getContactList()
+		
 	if message.body != None:
-		text = getQuery(message.body)
+		text = getQuery(contactList,message.body,CONST_MESSAGE)
 		if text:
-			contact = getContact(message.body)
-			if contact:
-				if contact.lower().find('madsen') <> -1:
-					try:
-						sendMail("5178813592@vtext.com",text)
-						ircMessage.newRoomMessage(irc, "Text message sent to" + contact).send()
-					except:
-						return
-				elif contact.lower().find('phyll1s') <> -1:
-					try:
-						sendMail("5179270394@vtext.com",text)
-						ircMessage.newRoomMessage(irc, "Text message sent to" + contact).send()
-					except:
-						return
-				elif (contact.lower().find('luke') <> -1) or (contact.lower().find('stilts') <> -1):
-					try:
-						sendMail("5176041672@vtext.com",text)
-						ircMessage.newRoomMessage(irc, "Text message sent to" + contact).send()
-					except:
-						return
-				elif (contact.lower().find('jimmy') <> -1) or (contact.lower().find('jimjim') <> -1):
-					try:
-						sendMail("2102964231@vtext.com",text)
-						ircMessage.newRoomMessage(irc, "Text message sent to" + contact).send()
-					except:
-						return
-				elif (contact.lower().find('popa') <> -1) or (contact.lower().find('mov1s') <> -1):
-					try:
-						sendMail("5172421175@messaging.sprintpcs.com",text)
-						ircMessage.newRoomMessage(irc, "Text message sent to" + contact).send()
-					except:
-						return
+			contact = getQuery(contactList,message.body,CONST_CONTACT)
+			if getContacts(contactList).find(contact) <> -1:
+				try:
+					sendMail(contactList,contact,text)
+					ircMessage.newRoomMessage(irc, "Text message sent to " + contact).send()
+				except:
+					return
 			else:
 				ircMessage.newRoomMessage(irc, "Does not match any known contact.").send()


### PR DESCRIPTION
smsModule now reads from smsConfig. The first two lines are the email and password for rafiBot. After that point it is name then the next line is the email address for the name. To have multiple names per number the format is name| altName. This will keep our names and phone numbers off of gitHub. I have the sample config file if anyone would like it.
